### PR TITLE
Add Atom feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,6 @@ email: kitsunyan@airmail.cc
 language: en_US
 permalink: none
 markdown: kramdown
+plugins:
+    - jekyll-feed
+author: kitsunyan

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,7 @@
 }}{% if page.id %}
 <meta property="og:image" content="{{ site.url }}{{ site.baseurl }}/assets/{{ page.id | remove: '/' }}/thumbnail.jpeg">{{
 }}{% endif %}
+<link rel="alternate" type="application/atom+xml" title="Foxy Blog" href="{{ site.baseurl}}/feed.xml">
 </head>
 <body>
 <header class="site-header">


### PR DESCRIPTION
Hi! You've got a really cool blog ^_^ I'd like to be notified about new posts, so I added an RSS (actually Atom) feed.

I don't know the first thing about Jekyll; the changes here are essentially a copy-paste of this excellent blog post: https://dzhavat.github.io/2020/01/19/adding-an-rss-feed-to-github-pages.html Please take a look at it, and also at [the jekyll-feed](https://github.com/jekyll/jekyll-feed) docs. You might want to add a wordier description for the feed, or add a prominent link somewhere in the HTML (the `<link>` that I added is for machines, not people).